### PR TITLE
Change error logging.

### DIFF
--- a/lib/broom.js
+++ b/lib/broom.js
@@ -44,8 +44,7 @@ Broom.prototype._handleFile = function(path){
     assert.ok(fileHandler[this.convention.dependenciesName],'dependencies');
     assert.ok(fileHandler[this.convention.entryName],'start');
   }catch(e){
-    console.log('cannot handle file '+path);
-    console.dir(e);
+    console.log('cannot handle file \''+path.path+'\'');
     return false;
   }
   var deps = {};


### PR DESCRIPTION
Instead of `cannot handle file [object Object]`
use `cannot handle file '/path/to/project/path/to/module/'`
